### PR TITLE
Ballot NS004 - Updating Section 4 - Vulnerability Management - of the NSRs

### DIFF
--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -483,8 +483,6 @@ Some common network and system threats include, but are not limited to:
 
 #### 4.3 Vulnerability Correction Process
 
-The CA's vulnerability identification process MUST include monitoring for relevant security advisories and penetration testing.
-
 The CA MUST document and follow a vulnerability correction process that includes:
 
    1. identification;
@@ -495,7 +493,7 @@ The CA MUST document and follow a vulnerability correction process that includes
 A vulnerability is remediated when the CA has:
 
 * fixed the vulnerability such that the vulnerability is no longer present; or
-* confirmed the impact of the vulnerability and thoroughly documented why the vulnerability cannot be exploited.
+* confirmed the impact of the vulnerability and documented why the vulnerability does not impact the CA's security posture.
 
 #### 4.4 Vulnerability Identification
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -179,7 +179,7 @@ Each factor is independent of the other(s).
 
 ## Requirements
 
-Prior to 2025-04-22, the CA SHALL adhere to these Requirements or Version 2.0 of the Network and Certificate System Security Requirements. Effective 2025-04-22, the CA SHALL adhere to these Requirements.
+Effective 2025-04-29, the CA SHALL adhere to these Requirements.
 
 ### 1. CA Infrastructure and Network Equipment Configuration
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -464,7 +464,7 @@ Certification Authorities MUST implement policies and procedures for identifying
 
 Certification Authorities MUST define an inventory of systems that perform the following CA functions: certificate request, certificate validation, signing, certificate revocation, serving certificate status information, key escrow. Policies and procedures MUST apply to all systems in the inventory of systems.
 
-The policies and procedures SHOULD also apply to Systems which perform Audit Logging and Monitoring, IDPSes andSystems which perform/manage user or machine authentication.
+The policies and procedures SHOULD also apply to Systems which perform Audit Logging and Monitoring, IDPSes and Systems which perform/manage user or machine authentication.
 
 ## 4.2 Vulnerability management timeframe
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -179,7 +179,7 @@ Each factor is independent of the other(s).
 
 ## Requirements
 
-Prior to 2024-11-12, the CA SHALL adhere to these Requirements or Version 1.7 of the Network and Certificate System Security Requirements. Effective 2024-11-12, the CA SHALL adhere to these Requirements.
+Prior to 2025-04-22, the CA SHALL adhere to these Requirements or Version 2.0 of the Network and Certificate System Security Requirements. Effective 2025-04-22, the CA SHALL adhere to these Requirements.
 
 ### 1. CA Infrastructure and Network Equipment Configuration
 
@@ -522,4 +522,4 @@ The risk assessment MUST be based on a documented security analysis. The securit
 
 The CA MUST ensure vulnerabilities are reviewed, responded to, and remediated in accordance with their established timeframe(s).
 
-Effective April 22, 2025, the CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.
+The CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -74,15 +74,16 @@ The following are outcomes that this document seeks to achieve:
 
 **Certificate System**: A system used by a CA or Delegated Third Party to access, process, or manage data or provide services related to:
 
-   1. identity validation;
-   2. identity authentication;
-   3. account registration;
-   4. certificate application;
-   5. certificate approval;
-   6. certificate issuance;
-   7. certificate revocation;
-   8. authoritative certificate status; or
-   9. key escrow.
+   1.  identity validation;
+   2.  identity authentication;
+   3.  account registration;
+   4.  certificate application;
+   5.  certificate validation;
+   7.  certificate approval;
+   7.  certificate issuance;
+   8.  certificate revocation;
+   9.  authoritative certificate status; or
+   10. key escrow.
 
 **Common Vulnerability Scoring System (CVSS)**: A quantitative model used to measure the base level severity of a vulnerability (see <http://nvd.nist.gov/vuln-metrics/cvss>).
 
@@ -457,35 +458,71 @@ The CA SHOULD ensure incident response plans minimally include:
    2. containment of the incident to minimize further impact; and
    3. identification and mitigation or eradication of the incident root cause(s).
 
-# 4. Vulnerability Management
-Certification Authorities MUST implement policies and procedures for identifying, evaluating, and resolving security vulnerabilities. 
+### 4. Vulnerability Management
 
-## 4.1 Inventory of Systems
+The CA MUST minimally implement the policies and procedures in this Section for identifying, evaluating, and resolving security vulnerabilities.
 
-Certification Authorities MUST define an inventory of systems that perform the following CA functions: certificate request, certificate validation, signing, certificate revocation, serving certificate status information, key escrow. Policies and procedures MUST apply to all systems in the inventory of systems.
+These policies and procedures MUST apply to all Certificate Systems.
 
-The policies and procedures SHOULD also apply to Systems which perform Audit Logging and Monitoring, IDPSes and Systems which perform/manage user or machine authentication.
+These policies and procedures SHOULD apply to Security Support Systems.
 
-## 4.2 Vulnerability management timeframe
+#### 4.1 Inventory of Certificate Systems
 
-Certification Authorities MUST establish a risk-based timeframe for responding and remediating critical and non-critical vulnerabilities.
+The CA MUST define an inventory of Certificate Systems.
 
-## 4.3 Intrusion Detection and Prevention
+#### 4.2 Vulnerability management timeframe
 
-Intrusion detection and prevention controls MUST protect the inventory of systems against common network and system threats.
+The CA MUST establish a timeframe for responding to and remediating critical and non-critical vulnerabilities.
+This timeframe MUST be established based on a risk assessment performed by the CA.
+The risk assessment MUST be based on a documented security analysis.
+The security analysis SHOULD take into account and address the following principles:
 
-## 4.4 Vulnerability Correction
+* criticality of assets;
+* maintaining confidentiality, integrity, and availability of assets;
+* risk tolerance;
+* regulatory requirements;
+* likelihood and impact of exploitation;
+* dependencies and interdependencies;
+* remediation resource requirements;
+* historical data; and
+* present threat landscape.
 
-A documented vulnerability correction process MUST be comprised of:  
-  1. periodic vulnerability scanning;
-  2. identification; 
-  3. review;
-  4. response; and 
-remediation  (i.e. vulnerabilities are tracked to ensure their remediation is completed within a defined timeframe)
+The CA MUST ensure critical and non-critical vulnerabilities are responded to and remediated in accordance with their established timeframe.
 
-## 4.5 Penetration Testing
+The CA MUST document in their Certificate Policy and/or Certification Practices Statement the timeframe established for responding to and remediating critical and non-critical vulnerabilities.
 
-A defined program for performing penetration tests MUST ensure that:
-  1. penetration tests are performed at least on an annual basis and after infrastructure or application changes that are organizationally defined as significant;
-  2. penetration tests are performed by a person or entity (or collective group thereof) with the necessary skills, tools, proficiency, code of ethics, and sufficient independence; and
-  3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in section 4.4.
+#### 4.3 Intrusion Detection and Prevention
+
+Intrusion detection and prevention controls MUST protect the inventory of Certificate Systems against common network and system threats.
+
+Some common network and system threats include, but are not limited to:
+
+* malicious software;
+* phishing and social engineering;
+* denial of service;
+* unauthorized access; and
+* malicious data injection.
+
+#### 4.4 Vulnerability Correction
+
+The CA MUST document and follow a vulnerability correction process.
+
+A documented vulnerability correction process MUST minimally be comprised of:  
+
+   1. periodic vulnerability scanning;
+   2. identification;
+   3. review;
+   4. response; and
+   5. remediation  (i.e. vulnerabilities are tracked to ensure their remediation is completed within a defined timeframe).
+
+#### 4.5 Penetration Testing
+
+The CA MUST define and follow a program for performing penetration tests.
+
+A defined program for performing penetration tests MUST minimally ensure that:
+
+   1. penetration tests are performed:
+      * at least on an annual basis; and
+      * after infrastructure or application changes that are organizationally defined as significant; and
+   2. penetration tests are performed by a person or entity (or collective group thereof) with the requisite skills, tools, proficiency, code of ethics, and independence; and
+   3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in [Section 4.4](#44-vulnerability-correction).

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -499,6 +499,8 @@ A vulnerability is remediated when the CA has:
 
 #### 4.4 Vulnerability Identification
 
+The CA's vulnerability identification process MUST include monitoring for relevant security advisories and penetration testing.
+
 ##### 4.4.1 Penetration Testing
 
 As part of the identification component of the CA's vulnerability correction process, the CA MUST define and follow a program for performing penetration tests that ensures:

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -109,7 +109,7 @@ Each factor is independent of the other(s).
 
 **National Vulnerability Database (NVD)**: A database that includes the Common Vulnerability Scoring System (CVSS) scores of security-related software flaws, misconfigurations, and vulnerabilities associated with systems (see <http://nvd.nist.gov/>).
 
-**Network Equipment**: Hardware devices and components that facilitate communication and data transfer within the CA Infrastructure.
+**Network Equipment**: Hardware devices and other components that facilitate communication and data transfer within the CA Infrastructure.
 
 **OWASP Top Ten**: A list of application vulnerabilities published by the Open Web Application Security Project (see <https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project>).
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -72,7 +72,7 @@ The following are outcomes that this document seeks to achieve:
 
 **Certificate Management System**: A system used by a CA or Delegated Third Party to process, approve issuance of, or store certificates or certificate status information, including the database, database server, and storage.
 
-**Certificate System**: A system used by a CA or Delegated Third Party to access, process, or manage data or provide services related to:
+**Certificate System**: A system used by a CA or Delegated Third Party to access, process, or manage data or provide services related to performing:
 
    1. identity validation;
    2. identity authentication;
@@ -81,7 +81,7 @@ The following are outcomes that this document seeks to achieve:
    5. certificate approval;
    6. certificate issuance;
    7. certificate revocation;
-   8. authoritative certificate status; or
+   8. generation and signing of authoritative certificate status; or
    9. key escrow.
 
 **Common Vulnerability Scoring System (CVSS)**: A quantitative model used to measure the base level severity of a vulnerability (see <http://nvd.nist.gov/vuln-metrics/cvss>).

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -105,8 +105,6 @@ Each factor is independent of the other(s).
 
 **Network Equipment**: Hardware devices and other components that facilitate communication and data transfer within the CA Infrastructure.
 
-**OWASP Top Ten**: A list of application vulnerabilities published by the Open Web Application Security Project (see <https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project>).
-
 **Physically Secure Environment**:  A controlled and protected physical space consisting minimally of a physical environment which is:
 
 1. protected by security controls which address the topics outlined in [section 4.5.1 of RFC 3647](https://datatracker.ietf.org/doc/html/rfc3647#section-4.5.1); and

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -457,37 +457,35 @@ The CA SHOULD ensure incident response plans minimally include:
    2. containment of the incident to minimize further impact; and
    3. identification and mitigation or eradication of the incident root cause(s).
 
-### 4. Vulnerability Detection and Patch Management
+# 4. Vulnerability Management
+Certification Authorities MUST implement policies and procedures for identifying, evaluating, and resolving security vulnerabilities. 
 
-Certification Authorities and Delegated Third Parties SHALL:
+## 4.1 Inventory of Systems
 
-a. Implement intrusion detection and prevention controls under the control of CA or Delegated Third Party Trusted Roles to protect Certificate Systems against common network and system threats;
+Certification Authorities MUST define an inventory of systems that perform the following CA functions: certificate request, certificate validation, signing, certificate revocation, serving certificate status information, key escrow. Policies and procedures MUST apply to all systems in the inventory of systems.
 
-b. Document and follow a vulnerability correction process that addresses the identification, review, response, and remediation of vulnerabilities;
+The policies and procedures SHOULD also apply to Systems which perform Audit Logging and Monitoring, IDPSes andSystems which perform/manage user or machine authentication.
 
-c. Undergo or perform a Vulnerability Scan
+## 4.2 Vulnerability management timeframe
 
-   1. within one (1) week of receiving a request from the CA/Browser Forum,
-   2. after any system or network changes that the CA determines are significant, and
-   3. at least every three (3) months, on public and private IP addresses identified by the CA or Delegated Third Party as the CA’s or Delegated Third Party’s Certificate Systems;
+Certification Authorities MUST establish a risk-based timeframe for responding and remediating critical and non-critical vulnerabilities.
 
-d. Undergo a Penetration Test on the CA’s and each Delegated Third Party’s Certificate Systems on at least an annual basis and after infrastructure or application upgrades or modifications that the CA determines are significant;
+## 4.3 Intrusion Detection and Prevention
 
-e. Record evidence that each Vulnerability Scan and Penetration Test was performed by a person or entity (or collective group thereof) with the skills, tools, proficiency, code of ethics, and independence necessary to provide a reliable Vulnerability Scan or Penetration Test; and
+Intrusion detection and prevention controls MUST protect the inventory of systems against common network and system threats.
 
-f. Do one of the following within ninety-six (96) hours of discovery of a Critical Vulnerability not previously addressed by the CA’s vulnerability correction process:
+## 4.4 Vulnerability Correction
 
-   1. Remediate the Critical Vulnerability;
-   2. If remediation of the Critical Vulnerability within ninety-six (96) hours is not possible, create and implement a plan to mitigate the Critical Vulnerability, giving priority to
+A documented vulnerability correction process MUST be comprised of:  
+  1. periodic vulnerability scanning;
+  2. identification; 
+  3. review;
+  4. response; and 
+remediation  (i.e. vulnerabilities are tracked to ensure their remediation is completed within a defined timeframe)
 
-      i. vulnerabilities with high CVSS scores, starting with the vulnerabilities the CA determines are the most critical (such as those with a CVSS score of 10.0) and
-      ii. systems that lack sufficient compensating controls that, if the vulnerability were left unmitigated, would allow external system control, code execution, privilege escalation, or system compromise; or
+## 4.5 Penetration Testing
 
-   3. Document the factual basis for the CA’s determination that the vulnerability does not require remediation because
-
-      i. the CA disagrees with the NVD rating,
-      ii. the identification is a false positive,
-      iii. the exploit of the vulnerability is prevented by compensating controls or an absence of threats; or
-      iv. other similar reasons.
-
-g. Apply recommended security patches to Certificate Systems within six (6) months of the security patch's availability, unless the CA documents that the security patch would introduce additional vulnerabilities or instabilities that outweigh the benefits of applying the security patch.
+A defined program for performing penetration tests MUST ensure that:
+  1. penetration tests are performed at least on an annual basis and after infrastructure or application changes that are organizationally defined as significant;
+  2. penetration tests are performed by a person or entity (or collective group thereof) with the necessary skills, tools, proficiency, code of ethics, and sufficient independence; and
+  3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in section 4.4.

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -74,16 +74,15 @@ The following are outcomes that this document seeks to achieve:
 
 **Certificate System**: A system used by a CA or Delegated Third Party to access, process, or manage data or provide services related to:
 
-   1.  identity validation;
-   2.  identity authentication;
-   3.  account registration;
-   4.  certificate application;
-   5.  certificate validation;
-   7.  certificate approval;
-   7.  certificate issuance;
-   8.  certificate revocation;
-   9.  authoritative certificate status; or
-   10. key escrow.
+   1. identity validation;
+   2. identity authentication;
+   3. account registration;
+   4. certificate application;
+   5. certificate approval;
+   6. certificate issuance;
+   7. certificate revocation;
+   8. authoritative certificate status; or
+   9. key escrow.
 
 **Common Vulnerability Scoring System (CVSS)**: A quantitative model used to measure the base level severity of a vulnerability (see <http://nvd.nist.gov/vuln-metrics/cvss>).
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -483,6 +483,8 @@ Some common network and system threats include, but are not limited to:
 
 #### 4.3 Vulnerability Correction Process
 
+The CA's vulnerability identification process MUST include monitoring for relevant security advisories and penetration testing.
+
 The CA MUST document and follow a vulnerability correction process that includes:
 
    1. identification;

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -473,15 +473,7 @@ The CA MUST define an inventory of Certificate Systems.
 
 The CA MUST protect the systems in the inventory of Certificate Systems against common network and system threats using intrusion detection and prevention controls.
 
-Some common network and system threats include, but are not limited to:
-
-* malicious software;
-* phishing and social engineering;
-* denial of service;
-* unauthorized access; and
-* malicious data injection.
-
-#### 4.3 Vulnerability Correction Process
+#### 4.3 Vulnerability Management Lifecycle
 
 The CA MUST document and follow a vulnerability correction process that includes:
 
@@ -490,16 +482,11 @@ The CA MUST document and follow a vulnerability correction process that includes
    1. response; and
    1. remediation.
 
-A vulnerability is remediated when the CA has:
-
-* fixed the vulnerability such that the vulnerability is no longer present; or
-* confirmed the impact of the vulnerability and documented why the vulnerability does not impact the CA's security posture.
-
-#### 4.4 Vulnerability Identification
+##### 4.3.1 Vulnerability Identification
 
 The CA's vulnerability identification process MUST include monitoring for relevant security advisories and penetration testing.
 
-##### 4.4.1 Penetration Testing
+###### 4.3.1.1 Penetration Testing
 
 As part of the identification component of the CA's vulnerability correction process, the CA MUST define and follow a program for performing penetration tests that ensures:
 
@@ -507,17 +494,22 @@ As part of the identification component of the CA's vulnerability correction pro
       * at least on an annual basis; and
       * after infrastructure or application changes that are organizationally defined as significant; and
    2. penetration tests are performed by a person or entity (or collective group thereof) with the requisite skills, tools, proficiency, code of ethics, and independence; and
-   3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in [Section 4.3](#43-vulnerability-correction-process).
+   3. vulnerabilities identified during the penetration test are remediated using the vulnerability correction process in [Section 4.3](#43-vulnerability-management-lifecycle).
 
-#### 4.5 Vulnerability Management Timeframe
+##### 4.3.2 Vulnerability Remediation
+
+A vulnerability is remediated when the CA has:
+
+* fixed the vulnerability such that the vulnerability is no longer present; or
+* confirmed the impact of the vulnerability and documented why the vulnerability does not impact the CA's security posture.
+
+#### 4.4 Vulnerability Management Timeframe
 
 The CA MUST establish one or more timeframes for reviewing, responding to, and remediating all identified vulnerabilities.
 
 Each timeframe MUST be established based on a risk assessment performed by the CA.
 
-The risk assessment MUST be based on a documented security analysis.
-
-The security analysis SHOULD take into account and address the following principles:
+The risk assessment MUST be based on a documented security analysis. The security analysis SHOULD take into account and address the following principles:
 
 * criticality of assets;
 * maintaining confidentiality, integrity, and availability of assets;

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -3,7 +3,7 @@ title: Network and Certificate System Security Requirements
 subtitle: Version 2.0
 author:
   - CA/Browser Forum
-date: 05 June, 2024
+date: 24 October, 2024
 copyright: |
   Copyright 2024 CA/Browser Forum
 
@@ -84,11 +84,7 @@ The following are outcomes that this document seeks to achieve:
    8. generation and signing of authoritative certificate status; or
    9. key escrow.
 
-**Common Vulnerability Scoring System (CVSS)**: A quantitative model used to measure the base level severity of a vulnerability (see <http://nvd.nist.gov/vuln-metrics/cvss>).
-
 **Critical Security Event**: An event, set of circumstances, or anomalous activity that could lead to a circumvention of CA Infrastructure security controls or compromise of CA Infrastructure integrity or operational continuity, including, but not limited to, excessive login attempts, attempts to access prohibited resources, DoS/DDoS attacks, attacker reconnaissance, excessive traffic at unusual hours, signs of unauthorized access, system intrusion, or physical compromise of component integrity.
-
-**Critical Vulnerability**: A system vulnerability that has a CVSS v2.0 score of 7.0 or higher according to the NVD or an equivalent to such CVSS rating (see <https://nvd.nist.gov/vuln-metrics/cvss>), or as otherwise designated as a Critical Vulnerability by the CA or the CA/Browser Forum.
 
 **Delegated Third Party**: A natural person or legal entity that is not the CA and that operates any part of a Certificate System.
 
@@ -107,13 +103,9 @@ Each factor is independent of the other(s).
 
 **Multi-Party Control**: An access control mechanism which requires two or more separate, authorized users to successfully authenticate with their own unique credentials prior to access being granted.
 
-**National Vulnerability Database (NVD)**: A database that includes the Common Vulnerability Scoring System (CVSS) scores of security-related software flaws, misconfigurations, and vulnerabilities associated with systems (see <http://nvd.nist.gov/>).
-
 **Network Equipment**: Hardware devices and other components that facilitate communication and data transfer within the CA Infrastructure.
 
 **OWASP Top Ten**: A list of application vulnerabilities published by the Open Web Application Security Project (see <https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project>).
-
-**Penetration Test**: A process that identifies and attempts to exploit openings and vulnerabilities on systems through the active use of known attack techniques, including the combination of different types of exploits, with a goal of breaking through layers of defenses and reporting on unpatched vulnerabilities and system weaknesses.
 
 **Physically Secure Environment**:  A controlled and protected physical space consisting minimally of a physical environment which is:
 
@@ -153,8 +145,6 @@ Each factor is independent of the other(s).
    2. store a Root CA Private Key; or
    3. create digital signatures using a Root CA Private Key.
 
-**SANS Top 25**: A list created with input from the SysAdmin, Audit, Network, and Security (SANS) Institute and the Common Weakness Enumeration (CWE) that identifies the Top 25 Most Dangerous Software Errors that lead to exploitable vulnerabilities (see <http://www.sans.org/top25-software-errors/>).
-
 **Security Support System**: A system or set of systems supporting the security of the CA Infrastructure, which minimally includes:
 
    1. authentication;
@@ -170,8 +160,6 @@ Each factor is independent of the other(s).
 
 **Trusted Role**: An employee or contractor of a CA or Delegated Third Party who has authorized access to any component of CA Infrastructure.
 
-**Vulnerability Scan**: A process that uses manual or automated tools to probe internal and external systems to check and report on the status of operating systems, services, and devices exposed to the network and the presence of vulnerabilities listed in the NVD, OWASP Top Ten, or SANS Top 25.
-
 **Workstation**: A device, such as a phone, tablet, or desktop or laptop computer, which is:
 
    1. connected to the same network as CA Infrastructure and/or Network Equipment; and
@@ -179,7 +167,7 @@ Each factor is independent of the other(s).
 
 ## Requirements
 
-The CA SHALL adhere to these Requirements on or before 2025-04-29.
+Prior to 2025-03-12, the CA SHALL adhere to these Requirements or Version 1.7 of the Network and Certificate System Security Requirements. Effective 2025-03-12, the CA SHALL adhere to these Requirements.
 
 ### 1. CA Infrastructure and Network Equipment Configuration
 

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -459,7 +459,7 @@ The CA SHOULD ensure incident response plans minimally include:
 
 ### 4. Vulnerability Management
 
-The CA MUST minimally implement the policies and procedures in this Section for identifying, evaluating, and resolving security vulnerabilities.
+The CA MUST implement the policies and procedures in this Section for identifying, evaluating, and resolving security vulnerabilities.
 
 These policies and procedures MUST apply to all Certificate Systems.
 
@@ -504,9 +504,7 @@ Some common network and system threats include, but are not limited to:
 
 #### 4.4 Vulnerability Correction
 
-The CA MUST document and follow a vulnerability correction process.
-
-A documented vulnerability correction process MUST minimally be comprised of:  
+The CA MUST document and follow a vulnerability correction process that includes:
 
    1. periodic vulnerability scanning;
    2. identification;
@@ -518,7 +516,7 @@ A documented vulnerability correction process MUST minimally be comprised of:
 
 The CA MUST define and follow a program for performing penetration tests.
 
-A defined program for performing penetration tests MUST minimally ensure that:
+A defined program for performing penetration tests MUST ensure that:
 
    1. penetration tests are performed:
       * at least on an annual basis; and

--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -179,7 +179,7 @@ Each factor is independent of the other(s).
 
 ## Requirements
 
-Effective 2025-04-29, the CA SHALL adhere to these Requirements.
+The CA SHALL adhere to these Requirements on or before 2025-04-29.
 
 ### 1. CA Infrastructure and Network Equipment Configuration
 


### PR DESCRIPTION
**Summary**: Section 4 of the Network and Certificate System Security Requirements (NCSSRs) stipulates that CAs have to perform a number of vulnerability management practices and emphasizes regular vulnerability scans and penetration tests. This Ballot proposes to replace Section 4 with a more comprehensive vulnerability management approach that is not limited to specific practices. Vulnerability scans and penetration tests are useful controls for some CA system environments but they are insufficient if they are not embedded in a broader set of policies and procedures that take CA specific risks into account.  The network and system architecture can differ significantly between CAs. CAs should identify and address vulnerabilities based on the risks in their respective environments .

We propose that CAs should address all vulnerabilities within their own predefined timelines that must be commensurate with the risks they introduce. To meet the requirements of the new Section 4, CAs need to demonstrate that they have developed and implemented an effective vulnerability management program. We expect the CAs’ auditors to verify that remediation timelines are defined, measurable and adequate. This will replace the specific rule that limits remediation tracking to only critical vulnerabilities and within a 96 hour timeline. We have determined that this is an insufficient mechanism to achieve vulnerability management as multiple lower risk issues can also create an insecure system.

Similarly, CAs must create a policy definition of what network or system changes they regard as significant and require an additional (non-periodic) penetration test. The definition can vary from CA to CA. As a guideline, we assume that changes which alter the data flow or introduce new service integrations are typically significant. Penetration tests must still be performed by qualified and independent internal or external penetration testers as stated in the requirements.

All systems that are involved in performing CA functions must be in scope of the vulnerability management program. After multiple discussions in the NetSec and other meetings it has been determined that the system definitions in the NCSSRs can be interpreted in multiple different ways. This could create an inconsistency in what may be audited across CAs. To resolve this we propose two changes to Section 4. First, we have defined the functions of a CA. Second, CAs will be formally required to maintain an inventory of systems instead.

**This Pull Request**:

-  Makes changes to section 4 of the Network and Certificate System  Security Requirements 

**How can you help?**

- Better: Add comments to this Pull Request.
- Best: Add suggested edits directly to this Pull Request.