### PR TITLE
NS007 Extend Deadline to Implement NSR v2

### DIFF
--- a/docs/NSR.md
+++ b/docs/NSR.md
@@ -169,7 +169,7 @@ Each factor is independent of the other(s).
 
 ## Requirements
 
-Prior to 2025-03-12, the CA SHALL adhere to these Requirements or Version 1.7 of the Network and Certificate System Security Requirements. Effective 2025-03-12, the CA SHALL adhere to these Requirements.
+Prior to 2025-09-17, the CA SHALL adhere to these Requirements or Version 1.7 of the Network and Certificate System Security Requirements. Effective 2025-09-17, the CA SHALL adhere to these Requirements.
 
 ### 1. CA Infrastructure and Network Equipment Configuration
 


### PR DESCRIPTION
In order to allow adequate time to properly review and refine the changes the restructuring we approved in NSR v2 bring to the table, this ballot extends the deadline to implement. 
The new deadline is 2025-09-17.
